### PR TITLE
Fixed issue with timer period

### DIFF
--- a/jniosemu/Utilities.java
+++ b/jniosemu/Utilities.java
@@ -71,7 +71,7 @@ public class Utilities
 		long ret = 0;
 
 		for (int i = 0; i < 8; i++)
-			ret |= ((long)value[i] << (8 * i));
+			ret |= ((value[i] & 0xFFL) << (8 * i));
 
 		return ret;
 	}

--- a/jniosemu/emulator/memory/io/TimerDevice.java
+++ b/jniosemu/emulator/memory/io/TimerDevice.java
@@ -74,7 +74,7 @@ public class TimerDevice extends MemoryBlock
 		this.clearState();
 
 		if (this.counting) {
-			if (this.counter > 0) {
+			if (this.counter != 0) {
 				this.counter--;
 			} else if ((this.memory[4] & 0x2) > 0) {
 				this.memory[0] |= 0x1;


### PR DESCRIPTION
Two issues resulted in unexpected handling of timer period.
1. When converting byte array to long, bytes were typecast to longs
which resulted in sign extension if the MSB was a 1. Solved by ANDing
long with 0xFF.
2. To check if the timer was finished, it was checking if count was
greater than zero which was false if the MSB was 1. Changed to !=
comparison which is safe because the enclosed decrement is the only way
count is decremented.

This issue is apparent when trying to set the period words (0x828 and 0x82C) to 0xFFFFFFFF or anything greater than 0x7F7F7F7F for that matter.
