### PR TITLE
Fixed issue with sign extension with I type

### DIFF
--- a/jniosemu/instruction/emulator/ITypeInstruction.java
+++ b/jniosemu/instruction/emulator/ITypeInstruction.java
@@ -21,14 +21,14 @@ public abstract class ITypeInstruction extends Instruction
 	/**
 	 * imm part of the instruction
 	 */
-	protected short imm;
+	protected int imm;
 
 	public ITypeInstruction(int opCode) {
 		this.opCode = opCode;
 
 		this.rA  = (opCode >>> 27) & 0x1F;
 		this.rB  = (opCode >>> 22) & 0x1F;
-		this.imm = (short)((opCode >>>  6) & 0xFFFF);
+		this.imm = ((opCode >>>  6) & 0xFFFF);
 	}
 
 	public abstract void run(Emulator em) throws EmulatorException;


### PR DESCRIPTION
Fixed issue with sign extension on immediate of I type instructions when
converting from short to int.

Before this fix the instruction "movi r8, 0xFFFF" ("addi r8, r0, 0xFFFF") would result is r8 = 0xFFFFFFFF. This was due to sign-extension when converting the immediate from a short to an int. This was fixed by always storing the immediate as an int.
