### PR TITLE
Revert "Fixed issue with sign extension with I type"

### DIFF
--- a/jniosemu/instruction/emulator/ITypeInstruction.java
+++ b/jniosemu/instruction/emulator/ITypeInstruction.java
@@ -21,14 +21,14 @@ public abstract class ITypeInstruction extends Instruction
 	/**
 	 * imm part of the instruction
 	 */
-	protected int imm;
+	protected short imm;
 
 	public ITypeInstruction(int opCode) {
 		this.opCode = opCode;
 
 		this.rA  = (opCode >>> 27) & 0x1F;
 		this.rB  = (opCode >>> 22) & 0x1F;
-		this.imm = ((opCode >>>  6) & 0xFFFF);
+		this.imm = (short)((opCode >>>  6) & 0xFFFF);
 	}
 
 	public abstract void run(Emulator em) throws EmulatorException;


### PR DESCRIPTION
This reverts commit c964418c02a55c73d81d713bdb161e2671fd6712 (PR #2).

The Altera docs clearly state that the ADDI instruction sign-extends the 16 bit immediate prior to addition. Thus, the original example is wrong.

This seems to fix tests: after reverting, all tests pass; before reverting, only 18 tests passed.
